### PR TITLE
Fix dictionary conversions and range checks

### DIFF
--- a/AES/Metrics/MetricsCalculator.cs
+++ b/AES/Metrics/MetricsCalculator.cs
@@ -34,7 +34,7 @@ public static class MetricsCalculator
         {
             var row = actual[i] - minScore;
             var col = predicted[i] - minScore;
-            if (row is < 0 or >= categories || col is < 0 or >= categories)
+            if (row < 0 || row >= categories || col < 0 || col >= categories)
             {
                 continue;
             }
@@ -164,7 +164,7 @@ public static class MetricsCalculator
         {
             var row = actual[i] - minScore;
             var col = predicted[i] - minScore;
-            if (row is < 0 or >= size || col is < 0 or >= size)
+            if (row < 0 || row >= size || col < 0 || col >= size)
             {
                 continue;
             }

--- a/AES/Models/BatchScoreResult.cs
+++ b/AES/Models/BatchScoreResult.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text.Json;
 
 namespace AES.Evaluator.Models;
@@ -14,12 +16,16 @@ public sealed class BatchScoreResult
         IReadOnlyList<JsonElement> raw
     )
     {
-        Mapping = new ReadOnlyDictionary<string, int?>(mapping);
-        RationaleMap = new ReadOnlyDictionary<string, string?>(rationaleMap);
+        Mapping = new ReadOnlyDictionary<string, int?>(mapping is IDictionary<string, int?> mappingDict
+            ? mappingDict
+            : new Dictionary<string, int?>(mapping));
+        RationaleMap = new ReadOnlyDictionary<string, string?>(rationaleMap is IDictionary<string, string?> rationaleDict
+            ? rationaleDict
+            : new Dictionary<string, string?>(rationaleMap));
         LatencyMs = latencyMs;
         InputTokens = inputTokens;
         OutputTokens = outputTokens;
-        Raw = new ReadOnlyCollection<JsonElement>(raw);
+        Raw = new ReadOnlyCollection<JsonElement>(raw as IList<JsonElement> ?? raw.ToList());
     }
 
     public IReadOnlyDictionary<string, int?> Mapping { get; }


### PR DESCRIPTION
## Summary
- wrap dictionary and list inputs in mutable collections before creating read-only wrappers
- replace relational pattern matching with standard comparisons for score bounds

## Testing
- not run (environment missing dotnet SDK)


------
https://chatgpt.com/codex/tasks/task_e_68e01397e70c8325b20cdd77ad67534c