### PR TITLE
Replace SqlBulkCopy with batched inserts for Fabric compatibility

### DIFF
--- a/AES/Data/SqlPipelineResultWriter.cs
+++ b/AES/Data/SqlPipelineResultWriter.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
+using System.Data;
 using AES.Evaluator.Configuration;
 using AES.Evaluator.Models;
 using Azure.Core;
@@ -28,146 +28,143 @@ public sealed class SqlPipelineResultWriter : IPipelineResultWriter, IDisposable
 
     public async Task WritePredictionsAsync(IEnumerable<ScoredEssayRecord> predictions, CancellationToken cancellationToken)
     {
-        var records = predictions as IReadOnlyCollection<ScoredEssayRecord> ?? predictions.ToList();
+        var records = predictions as IReadOnlyList<ScoredEssayRecord> ?? predictions.ToList();
         if (records.Count == 0)
         {
             return;
         }
 
-        var table = new DataTable();
-        table.Columns.Add("Id", typeof(string));
-        table.Columns.Add("Year", typeof(string));
-        table.Columns.Add("EssayType", typeof(string));
-        table.Columns.Add("Score", typeof(int));
-        table.Columns.Add("PredScore", typeof(int));
-        table.Columns.Add("PredRationale", typeof(string));
-        table.Columns.Add("RunDate", typeof(string));
-        table.Columns.Add("RunId", typeof(string));
-        table.Columns.Add("Model", typeof(string));
-        table.Columns.Add("PromptType", typeof(string));
-        table.Columns.Add("Run", typeof(string));
-
-        foreach (var record in records)
+        var columns = new[]
         {
-            table.Rows.Add(
-                record.Id,
-                record.Year,
-                record.EssayType,
-                record.Score ?? (object)DBNull.Value,
-                record.PredScore ?? (object)DBNull.Value,
-                record.PredRationale ?? string.Empty,
-                record.RunDate,
-                record.RunId,
-                record.Model,
-                record.PromptType,
-                record.Run
-            );
-        }
+            new ColumnDefinition<ScoredEssayRecord>("Id", r => r.Id),
+            new ColumnDefinition<ScoredEssayRecord>("Year", r => r.Year),
+            new ColumnDefinition<ScoredEssayRecord>("EssayType", r => r.EssayType),
+            new ColumnDefinition<ScoredEssayRecord>("Score", r => r.Score, SqlDbType.Int),
+            new ColumnDefinition<ScoredEssayRecord>("PredScore", r => r.PredScore, SqlDbType.Int),
+            new ColumnDefinition<ScoredEssayRecord>("PredRationale", r => r.PredRationale ?? string.Empty),
+            new ColumnDefinition<ScoredEssayRecord>("RunDate", r => r.RunDate),
+            new ColumnDefinition<ScoredEssayRecord>("RunId", r => r.RunId),
+            new ColumnDefinition<ScoredEssayRecord>("Model", r => r.Model),
+            new ColumnDefinition<ScoredEssayRecord>("PromptType", r => r.PromptType),
+            new ColumnDefinition<ScoredEssayRecord>("Run", r => r.Run)
+        };
 
-        await BulkCopyAsync(table, _predictionsTableName, cancellationToken);
+        await InsertRecordsAsync(records, _predictionsTableName, columns, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task WriteUsageAsync(IEnumerable<UsageRecordWithRun> usageRecords, CancellationToken cancellationToken)
     {
-        var records = usageRecords as IReadOnlyCollection<UsageRecordWithRun> ?? usageRecords.ToList();
+        var records = usageRecords as IReadOnlyList<UsageRecordWithRun> ?? usageRecords.ToList();
         if (records.Count == 0)
         {
             return;
         }
 
-        var table = new DataTable();
-        table.Columns.Add("Year", typeof(string));
-        table.Columns.Add("EssayType", typeof(string));
-        table.Columns.Add("BatchIndex", typeof(int));
-        table.Columns.Add("Items", typeof(int));
-        table.Columns.Add("LatencyMs", typeof(int));
-        table.Columns.Add("InputTokens", typeof(int));
-        table.Columns.Add("OutputTokens", typeof(int));
-        table.Columns.Add("RunDate", typeof(string));
-        table.Columns.Add("RunId", typeof(string));
-        table.Columns.Add("Model", typeof(string));
-        table.Columns.Add("PromptType", typeof(string));
-        table.Columns.Add("Run", typeof(string));
-
-        foreach (var record in records)
+        var columns = new[]
         {
-            table.Rows.Add(
-                record.Year,
-                record.EssayType,
-                record.BatchIndex,
-                record.Items,
-                record.LatencyMs ?? (object)DBNull.Value,
-                record.InputTokens ?? (object)DBNull.Value,
-                record.OutputTokens ?? (object)DBNull.Value,
-                record.RunDate,
-                record.RunId,
-                record.Model,
-                record.PromptType,
-                record.Run
-            );
-        }
+            new ColumnDefinition<UsageRecordWithRun>("Year", r => r.Year),
+            new ColumnDefinition<UsageRecordWithRun>("EssayType", r => r.EssayType),
+            new ColumnDefinition<UsageRecordWithRun>("BatchIndex", r => r.BatchIndex, SqlDbType.Int),
+            new ColumnDefinition<UsageRecordWithRun>("Items", r => r.Items, SqlDbType.Int),
+            new ColumnDefinition<UsageRecordWithRun>("LatencyMs", r => r.LatencyMs, SqlDbType.Int),
+            new ColumnDefinition<UsageRecordWithRun>("InputTokens", r => r.InputTokens, SqlDbType.Int),
+            new ColumnDefinition<UsageRecordWithRun>("OutputTokens", r => r.OutputTokens, SqlDbType.Int),
+            new ColumnDefinition<UsageRecordWithRun>("RunDate", r => r.RunDate),
+            new ColumnDefinition<UsageRecordWithRun>("RunId", r => r.RunId),
+            new ColumnDefinition<UsageRecordWithRun>("Model", r => r.Model),
+            new ColumnDefinition<UsageRecordWithRun>("PromptType", r => r.PromptType),
+            new ColumnDefinition<UsageRecordWithRun>("Run", r => r.Run)
+        };
 
-        await BulkCopyAsync(table, _usageTableName, cancellationToken);
+        await InsertRecordsAsync(records, _usageTableName, columns, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task WriteMetricsAsync(IEnumerable<MetricSummary> metrics, CancellationToken cancellationToken)
     {
-        var records = metrics as IReadOnlyCollection<MetricSummary> ?? metrics.ToList();
+        var records = metrics as IReadOnlyList<MetricSummary> ?? metrics.ToList();
         if (records.Count == 0)
         {
             return;
         }
 
-        var table = new DataTable();
-        table.Columns.Add("RunDate", typeof(string));
-        table.Columns.Add("RunId", typeof(string));
-        table.Columns.Add("Model", typeof(string));
-        table.Columns.Add("PromptType", typeof(string));
-        table.Columns.Add("Run", typeof(string));
-        table.Columns.Add("Year", typeof(string));
-        table.Columns.Add("EssayType", typeof(string));
-        table.Columns.Add("count", typeof(int));
-        table.Columns.Add("accuracy", typeof(double));
-        table.Columns.Add("qwk", typeof(double));
-        table.Columns.Add("macro_f1", typeof(double));
-        table.Columns.Add("spearman_r", typeof(double));
-
-        foreach (var record in records)
+        var columns = new[]
         {
-            table.Rows.Add(
-                record.RunDate,
-                record.RunId,
-                record.Model,
-                record.PromptType,
-                record.Run,
-                record.Year,
-                record.EssayType,
-                record.Count,
-                record.Accuracy,
-                record.QuadraticWeightedKappa,
-                record.MacroF1,
-                record.SpearmanR
-            );
-        }
-
-        await BulkCopyAsync(table, _metricsTableName, cancellationToken);
-    }
-
-    private async Task BulkCopyAsync(DataTable table, string destinationTable, CancellationToken cancellationToken)
-    {
-        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var bulkCopy = new SqlBulkCopy(connection)
-        {
-            DestinationTableName = destinationTable
+            new ColumnDefinition<MetricSummary>("RunDate", r => r.RunDate),
+            new ColumnDefinition<MetricSummary>("RunId", r => r.RunId),
+            new ColumnDefinition<MetricSummary>("Model", r => r.Model),
+            new ColumnDefinition<MetricSummary>("PromptType", r => r.PromptType),
+            new ColumnDefinition<MetricSummary>("Run", r => r.Run),
+            new ColumnDefinition<MetricSummary>("Year", r => r.Year),
+            new ColumnDefinition<MetricSummary>("EssayType", r => r.EssayType),
+            new ColumnDefinition<MetricSummary>("count", r => r.Count, SqlDbType.Int),
+            new ColumnDefinition<MetricSummary>("accuracy", r => r.Accuracy, SqlDbType.Float),
+            new ColumnDefinition<MetricSummary>("qwk", r => r.QuadraticWeightedKappa, SqlDbType.Float),
+            new ColumnDefinition<MetricSummary>("macro_f1", r => r.MacroF1, SqlDbType.Float),
+            new ColumnDefinition<MetricSummary>("spearman_r", r => r.SpearmanR, SqlDbType.Float)
         };
 
-        foreach (DataColumn column in table.Columns)
+        await InsertRecordsAsync(records, _metricsTableName, columns, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertRecordsAsync<T>(IReadOnlyList<T> records, string destinationTable, IReadOnlyList<ColumnDefinition<T>> columns, CancellationToken cancellationToken)
+    {
+        const int DefaultBatchSize = 100;
+        const int MaxParametersPerCommand = 2000;
+
+        if (columns.Count == 0)
         {
-            bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
+            throw new InvalidOperationException("At least one column must be specified for an insert operation.");
         }
 
-        await bulkCopy.WriteToServerAsync(table, cancellationToken);
+        var effectiveBatchSize = Math.Max(1, Math.Min(DefaultBatchSize, MaxParametersPerCommand / columns.Count));
+        var columnList = string.Join(", ", columns.Select(c => $"[{c.Name}]"));
+
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+
+        for (var offset = 0; offset < records.Count; offset += effectiveBatchSize)
+        {
+            var batchSize = Math.Min(effectiveBatchSize, records.Count - offset);
+            using var command = connection.CreateCommand();
+            var valueClauses = new string[batchSize];
+
+            for (var rowIndex = 0; rowIndex < batchSize; rowIndex++)
+            {
+                var record = records[offset + rowIndex];
+                var parameterNames = new string[columns.Count];
+
+                for (var columnIndex = 0; columnIndex < columns.Count; columnIndex++)
+                {
+                    var parameterName = $"@p{rowIndex}_{columnIndex}";
+                    parameterNames[columnIndex] = parameterName;
+
+                    var value = columns[columnIndex].ValueFactory(record);
+                    SqlParameter parameter;
+                    if (columns[columnIndex].DbType.HasValue)
+                    {
+                        parameter = new SqlParameter(parameterName, columns[columnIndex].DbType.Value)
+                        {
+                            Value = value ?? DBNull.Value
+                        };
+                    }
+                    else
+                    {
+                        parameter = new SqlParameter(parameterName, value ?? DBNull.Value);
+                    }
+
+                    command.Parameters.Add(parameter);
+                }
+
+                valueClauses[rowIndex] = $"({string.Join(", ", parameterNames)})";
+            }
+
+            var values = string.Join(", ", valueClauses);
+            command.CommandText = $"INSERT INTO {destinationTable} ({columnList}) VALUES {values}";
+
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
+
+    private sealed record ColumnDefinition<T>(string Name, Func<T, object?> ValueFactory, SqlDbType? DbType = null);
 
     public void Dispose()
     {


### PR DESCRIPTION
## Summary
- replace SqlBulkCopy usage with parameterized multi-row INSERT statements for predictions, usage, and metrics tables
- add reusable helper that batches inserts within SQL parameter limits and supports per-column null handling and types

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e427dada848325876a8337dd70c906